### PR TITLE
Use less restrictive >= over ~>

### DIFF
--- a/devise-token_authenticatable.gemspec
+++ b/devise-token_authenticatable.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
 
-  spec.add_dependency "devise",                         "~> 3.3.0"
+  spec.add_dependency "devise",                         ">= 3.3.0"
 
   spec.add_development_dependency "rails",              "~> 4.1.0"
   spec.add_development_dependency "rspec-rails",        "~> 3.0.2"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 ENV["RAILS_ENV"] ||= 'test'
 
+require 'action_controller'
+
 # Required modules
 require 'devise'
 require 'devise/token_authenticatable'


### PR DESCRIPTION
The extra `require 'action_controller'` line in `spec_helper.rb` was required to prevent an error, `uninitialized constant ActionController::Metal` during testing.
