### PR TITLE
Add configuration options for reset authorization token and ensure autho...

### DIFF
--- a/lib/devise/token_authenticatable/model.rb
+++ b/lib/devise/token_authenticatable/model.rb
@@ -36,7 +36,13 @@ module Devise
     #
     module TokenAuthenticatable
       extend ActiveSupport::Concern
-
+      
+      Devise::Models.config(self, :should_reset_authentication_token, :should_ensure_authentication_token)
+      included do
+        before_save :reset_authentication_token if (should_reset_authentication_token ||= false)
+        before_save :ensure_authentication_token if (should_ensure_authentication_token ||= true)
+      end
+      
       def self.required_fields(klass)
         [:authentication_token]
       end


### PR DESCRIPTION
Since these are two of the huge insecurities in devise token authentication, they should be encouraged to be set more easily.

Note, a spec fails if you have reset on.