### PR TITLE
Add expiry for tokens

### DIFF
--- a/devise-token_authenticatable.gemspec
+++ b/devise-token_authenticatable.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
 
-  spec.add_dependency "devise",                         "~> 3.5.0"
+  spec.add_dependency "devise",                         "~> 3.4.1"
 
   spec.add_development_dependency "rails",              "~> 4.1.0"
   spec.add_development_dependency "rspec-rails",        "~> 3.0.2"

--- a/lib/devise/token_authenticatable.rb
+++ b/lib/devise/token_authenticatable.rb
@@ -7,6 +7,9 @@ module Devise
     mattr_accessor :token_authentication_key
     @@token_authentication_key = :auth_token
 
+    mattr_accessor :token_expires_in
+    @@token_expires_in = nil
+
     # Defines if the authentication token is reset before the model is saved.
     mattr_accessor :should_reset_authentication_token
     @@should_reset_authentication_token = false

--- a/lib/devise/token_authenticatable/model.rb
+++ b/lib/devise/token_authenticatable/model.rb
@@ -48,17 +48,18 @@ module Devise
           end
         end
 
-        Devise::Models.config(self, :expire_auth_token_on_timeout)
+        Devise::Models.config(self, :expire_auth_token_on_timeout, :token_expires_in)
 
       end
 
       def self.required_fields(klass)
-        [:authentication_token]
+        [:authentication_token,:authentication_token_created_at]
       end
 
       # Generate new authentication token (a.k.a. "single access token").
       def reset_authentication_token
         self.authentication_token = self.class.authentication_token
+        self.authentication_token_created_at = Time.now
       end
 
       # Generate new authentication token and save the record.
@@ -81,9 +82,14 @@ module Devise
       def after_token_authentication
       end
 
+      def token_expires_in
+        self.class.token_expires_in
+      end
+
       def expire_auth_token_on_timeout
         self.class.expire_auth_token_on_timeout
       end
+
 
       private
 

--- a/lib/devise/token_authenticatable/strategy.rb
+++ b/lib/devise/token_authenticatable/strategy.rb
@@ -36,6 +36,10 @@ module Devise
         resource = mapping.to.find_for_token_authentication(authentication_hash)
         return fail(:invalid_token) unless resource
 
+        unless token_expires_in.blank?
+          return fail(:expired_token) if Time.now > (resource.authentication_token_created_at + token_expires_in.to_i)
+        end
+
         if validate(resource)
           resource.after_token_authentication
           success!(resource)
@@ -87,6 +91,11 @@ module Devise
       # Overwrite authentication keys to use token_authentication_key.
       def authentication_keys
         @authentication_keys ||= [Devise::TokenAuthenticatable.token_authentication_key]
+      end
+
+      # Overwrite authentication keys to use token_authentication_key.
+      def token_expires_in
+        @token_expires_in ||= Devise::TokenAuthenticatable.token_expires_in
       end
     end
   end

--- a/lib/devise/token_authenticatable/version.rb
+++ b/lib/devise/token_authenticatable/version.rb
@@ -1,5 +1,5 @@
 module Devise
   module TokenAuthenticatable
-    VERSION = "0.4.1".freeze
+    VERSION = "0.4.2".freeze
   end
 end

--- a/lib/devise/token_authenticatable/version.rb
+++ b/lib/devise/token_authenticatable/version.rb
@@ -1,5 +1,5 @@
 module Devise
   module TokenAuthenticatable
-    VERSION = "0.4.0".freeze
+    VERSION = "0.4.1".freeze
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -6,6 +6,8 @@ FactoryGirl.define do
     password              'some_password'
     password_confirmation 'some_password'
     facebook_token        { SecureRandom.hex }
+    authentication_token_created_at nil
+    authentication_token nil
 
     ignore do
       confirm_account true
@@ -21,6 +23,12 @@ FactoryGirl.define do
 
     trait :with_authentication_token do
       authentication_token { SecureRandom.hex }
+      authentication_token_created_at { Time.now }
+    end
+
+    trait :with_day_old_token do
+      authentication_token { SecureRandom.hex }
+      authentication_token_created_at { Time.now - 1.day }
     end
   end
 end

--- a/spec/models/devise/token_authenticatable/model_spec.rb
+++ b/spec/models/devise/token_authenticatable/model_spec.rb
@@ -16,6 +16,7 @@ shared_examples "token authenticatable" do
 
       it "should reset authentication token" do
         expect { entity.reset_authentication_token }.to change { entity.authentication_token }
+        expect { entity.reset_authentication_token }.to change { entity.authentication_token_created_at }
       end
     end
 
@@ -35,6 +36,9 @@ shared_examples "token authenticatable" do
         it "should create an authentication token" do
           entity.authentication_token = nil
           expect { entity.ensure_authentication_token }.to change { entity.authentication_token }
+          entity.authentication_token = nil
+          entity.authentication_token_created_at = nil
+          expect { entity.ensure_authentication_token }.to change { entity.authentication_token_created_at }
         end
       end
     end
@@ -77,7 +81,7 @@ shared_examples "token authenticatable" do
 
       it "should contain the fields that Devise uses" do
         expect(Devise::Models::TokenAuthenticatable.required_fields(described_class)).to eq([
-          :authentication_token
+          :authentication_token, :authentication_token_created_at
         ])
       end
 

--- a/spec/requests/devise/token_authenticatable/strategy_spec.rb
+++ b/spec/requests/devise/token_authenticatable/strategy_spec.rb
@@ -56,7 +56,9 @@ describe Devise::Strategies::TokenAuthenticatable do
             expect(warden).to be_authenticated(:user)
           end
         end
+
       end
+
 
       context "when request is stateless" do
 
@@ -409,4 +411,42 @@ describe Devise::Strategies::TokenAuthenticatable do
       end
     end
   end
+
+  context "with expired authentication token value" do
+
+    context "through params" do
+
+      before {
+        swap Devise::TokenAuthenticatable, token_expires_in: 1.hour do
+          sign_in_as_new_user_with_token(with_day_old_token: true)
+        end
+      }
+
+      it "should redirect to the sign in page" do
+        expect(response).to redirect_to new_user_session_path
+      end
+
+      it "should not authenticate user" do
+        expect(warden).to_not be_authenticated(:user)
+      end
+    end
+
+    context "through http header" do
+
+      before {
+        swap Devise::TokenAuthenticatable, token_expires_in: 1.hour do
+          sign_in_as_new_user_with_token(with_day_old_token: true)
+        end
+      }
+
+      it "should redirect to the sign in page" do
+        expect(response).to redirect_to new_user_session_path
+      end
+
+      it "does not authenticate with expired authentication token value in header" do
+        expect(warden).to_not be_authenticated(:user)
+      end
+    end
+  end
+
 end

--- a/spec/support/rails_app/db/migrate/20100401102949_create_tables.rb
+++ b/spec/support/rails_app/db/migrate/20100401102949_create_tables.rb
@@ -35,6 +35,7 @@ class CreateTables < ActiveRecord::Migration
 
       ## Token authenticatable
       t.string :authentication_token
+      t.datetime :authentication_token_created_at, :null => true
 
       t.timestamps
     end

--- a/spec/support/rails_app/db/schema.rb
+++ b/spec/support/rails_app/db/schema.rb
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define(:version => 20100401102949) do
     t.string   "unlock_token"
     t.datetime "locked_at"
     t.string   "authentication_token"
+    t.datetime "authentication_token_created_at"
     t.datetime "created_at"
     t.datetime "updated_at"
   end

--- a/spec/support/session_helper.rb
+++ b/spec/support/session_helper.rb
@@ -7,7 +7,8 @@
 # a new one is created.
 #
 def sign_in_as_new_user_with_token(options = {})
-  user = options.delete(:user) || create(:user, :with_authentication_token)
+  trait = options[:with_day_old_token] ? :with_day_old_token : :with_authentication_token
+  user = options.delete(:user) || create(:user, trait)
 
   options[:auth_token_key] ||= Devise::TokenAuthenticatable.token_authentication_key
   options[:auth_token]     ||= user.authentication_token

--- a/spec/token_authenticatable_spec.rb
+++ b/spec/token_authenticatable_spec.rb
@@ -12,6 +12,19 @@ describe Devise::TokenAuthenticatable do
         end
       }.to change { Devise::TokenAuthenticatable.token_authentication_key }.from(:auth_token).to(new_key)
     end
+
+  end
+
+  context "configuring the token expiration" do
+    let(:expire_time) { 1.hour }
+
+    it "should set the configuration" do
+      expect {
+        Devise::TokenAuthenticatable.setup do |config|
+          config.token_expires_in = expire_time
+        end
+      }.to change { Devise::TokenAuthenticatable.token_authentication_key }.from(nil).to(expire_time)
+    end
   end
 
   context "configuring the should_reset_authentication_token" do


### PR DESCRIPTION
adds a configuration value and check for expired tokens, to create auth tokens that expire at a custom time