### PR TITLE
extend version support for devise 4.0.0

### DIFF
--- a/devise-token_authenticatable.gemspec
+++ b/devise-token_authenticatable.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
 
-  spec.add_dependency "devise",                         "~> 3.5.0"
+  spec.add_dependency "devise",                         ">= 3.5.0", "<= 4.0.0"
 
   spec.add_development_dependency "rails",              "~> 4.1.0"
   spec.add_development_dependency "rspec-rails",        "~> 3.0.2"


### PR DESCRIPTION
This to support Rails 5.

I'm already running this for a few days without problems.

`expire_authentication_token_on_timeout` was deprecated in Devise 3.5.2, which causes the tests to fail, don't know if this is functionality that has to reimplemented, or can be removed altogether.