### PR TITLE
Fix (break) expire auth token spec

### DIFF
--- a/spec/requests/devise/token_authenticatable/strategy_spec.rb
+++ b/spec/requests/devise/token_authenticatable/strategy_spec.rb
@@ -165,7 +165,7 @@ describe Devise::Strategies::TokenAuthenticatable do
             swap Devise::TokenAuthenticatable, token_authentication_key: :secret_token, expire_auth_token_on_timeout: true do
               swap Devise, timeout_in: (-1).minute do
                 user  = sign_in_as_new_user_with_token
-                token = user.authentication_token
+                token = user.reload.authentication_token
 
                 sign_in_as_new_user_with_token(user: user)
                 user.reload


### PR DESCRIPTION
@baschtl

```
Failures:

  1) Devise::Strategies::TokenAuthenticatable with valid authentication token key and value through params when expire_auth_token_on_timeout is set to true, timeoutable is enabled and we have a timed out session on re-sign in should reset the authentication token
     Failure/Error: expect(token).to_not eq(user.authentication_token)

       expected: value != "AHxr-cHaF8zpu9YKw3p4"
            got: "AHxr-cHaF8zpu9YKw3p4"

       (compared using ==)
     # ./spec/requests/devise/token_authenticatable/strategy_spec.rb:172:in `block (8 levels) in <top (required)>'
     # ./spec/support/helpers.rb:18:in `swap'
     # ./spec/requests/devise/token_authenticatable/strategy_spec.rb:166:in `block (7 levels) in <top (required)>'
     # ./spec/support/helpers.rb:18:in `swap'
     # ./spec/requests/devise/token_authenticatable/strategy_spec.rb:165:in `block (6 levels) in <top (required)>'
```