### PR TITLE
Make authentication_token_created_at field optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This gem can be configured as shown in the following:
 ```ruby
 Devise::TokenAuthenticatable.setup do |config|
   # enables the expiration of a token after a specified amount of time,
+  # requires an additional field on the model: `authentication_token_created_at`
   # defaults to nil
   config.token_expires_in = 1.day
 

--- a/lib/devise/token_authenticatable/model.rb
+++ b/lib/devise/token_authenticatable/model.rb
@@ -53,13 +53,19 @@ module Devise
       end
 
       def self.required_fields(klass)
-        [:authentication_token, :authentication_token_created_at]
+        fields = [:authentication_token]
+
+        unless Devise::TokenAuthenticatable.token_expires_in.blank?
+          fields.push(:authentication_token_created_at)
+        end
+
+        fields
       end
 
       # Generate new authentication token (a.k.a. "single access token").
       def reset_authentication_token
         self.authentication_token = self.class.authentication_token
-        self.authentication_token_created_at = Time.now
+        self.authentication_token_created_at = Time.now unless token_expires_in.blank?
       end
 
       # Generate new authentication token and save the record.

--- a/spec/models/devise/token_authenticatable/model_spec.rb
+++ b/spec/models/devise/token_authenticatable/model_spec.rb
@@ -18,8 +18,16 @@ shared_examples "token authenticatable" do
         expect { subject }.to change { entity.authentication_token }
       end
 
-      it "should reset token created at" do
-        expect { subject }.to change { entity.authentication_token_created_at }
+      context "token created at" do
+        it "should reset" do
+          swap Devise::TokenAuthenticatable, token_expires_in: 1.hour do
+            expect { subject }.to change { entity.authentication_token_created_at }
+          end
+        end
+
+        it "should not reset when token expires in not set" do
+          expect { subject }.to_not change { entity.authentication_token_created_at }
+        end
       end
     end
 
@@ -50,8 +58,16 @@ shared_examples "token authenticatable" do
           expect { subject }.to change { entity.authentication_token }
         end
 
-        it "should set authentication token created at" do
-          expect { subject }.to change { entity.authentication_token_created_at }
+        context "token created at" do
+          it "should set" do
+            swap Devise::TokenAuthenticatable, token_expires_in: 1.hour do
+              expect { subject }.to change { entity.authentication_token_created_at }
+            end
+          end
+
+          it "should not set when token expires in disabled" do
+            expect { subject }.to_not change { entity.authentication_token_created_at }
+          end
         end
       end
     end
@@ -89,10 +105,18 @@ shared_examples "token authenticatable" do
     end
 
     describe "#required_fields" do
-      it "should contain the fields that Devise uses" do
+      it "should contain the fields that Devise uses when token expires in disabled" do
         expect(Devise::Models::TokenAuthenticatable.required_fields(described_class)).to eq([
-          :authentication_token, :authentication_token_created_at
+          :authentication_token
         ])
+      end
+
+      it "should contain the fields that Devise uses" do
+        swap Devise::TokenAuthenticatable, token_expires_in: 1.hour do
+          expect(Devise::Models::TokenAuthenticatable.required_fields(described_class)).to eq([
+            :authentication_token, :authentication_token_created_at
+          ])
+        end
       end
     end
 


### PR DESCRIPTION
Only require `authentication_token_created_at` field on model when
`token_expires_in` config set.

To: @baschtl 
CC: @leonelgalan