### PR TITLE
Change name of http_authenticatable strategy to token

### DIFF
--- a/lib/devise/token_authenticatable/strategy.rb
+++ b/lib/devise/token_authenticatable/strategy.rb
@@ -57,7 +57,7 @@ module Devise
 
       # Check if the model accepts this strategy as token authenticatable.
       def token_authenticatable?
-        mapping.to.http_authenticatable?(:token_options)
+        mapping.to.http_authenticatable?(:token)
       end
 
       # Check if this is strategy is valid for token authentication by:

--- a/spec/requests/devise/token_authenticatable/strategy_spec.rb
+++ b/spec/requests/devise/token_authenticatable/strategy_spec.rb
@@ -224,7 +224,7 @@ describe Devise::Strategies::TokenAuthenticatable do
 
         it "should redirect to root path" do
           swap Devise::TokenAuthenticatable, token_authentication_key: :secret_token do
-            swap Devise, http_authenticatable: [:token_options] do
+            swap Devise, http_authenticatable: [:token] do
               sign_in_as_new_user_with_token(token_auth: true, token_options: { signature: signature, nonce: 'def' })
 
               expect(response).to be_success
@@ -234,7 +234,7 @@ describe Devise::Strategies::TokenAuthenticatable do
 
         it "should set the signature option" do
           swap Devise::TokenAuthenticatable, token_authentication_key: :secret_token do
-            swap Devise, http_authenticatable: [:token_options] do
+            swap Devise, http_authenticatable: [:token] do
               sign_in_as_new_user_with_token(token_auth: true, token_options: { signature: signature, nonce: 'def' })
 
               expect(request.env['devise.token_options'][:signature]).to eq(signature)
@@ -244,7 +244,7 @@ describe Devise::Strategies::TokenAuthenticatable do
 
         it "should set the nonce option" do
           swap Devise::TokenAuthenticatable, token_authentication_key: :secret_token do
-            swap Devise, http_authenticatable: [:token_options] do
+            swap Devise, http_authenticatable: [:token] do
               sign_in_as_new_user_with_token(token_auth: true, token_options: { signature: signature, nonce: 'def' })
 
               expect(request.env['devise.token_options'][:nonce]).to eq('def')
@@ -254,7 +254,7 @@ describe Devise::Strategies::TokenAuthenticatable do
 
         it "should authenticate user" do
           swap Devise::TokenAuthenticatable, token_authentication_key: :secret_token do
-            swap Devise, http_authenticatable: [:token_options] do
+            swap Devise, http_authenticatable: [:token] do
               sign_in_as_new_user_with_token(token_auth: true, token_options: { signature: signature, nonce: 'def' })
 
               expect(warden).to be_authenticated(:user)


### PR DESCRIPTION
Instead of having to specify `:token_options` as strategy name I switched to use `:token` to conform to the given example in devise.

This should fix https://github.com/baschtl/devise-token_authenticatable/issues/38.

Be aware that this is a breaking change since existing limitations using `:token_options` won't work anymore.