### PR TITLE
Adds support for devise 4.4 and Ruby 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.2.5
   - 2.3.1
   - 2.4.0
+  - 2.5.0
 
 before_install:
   - gem install bundler -v 1.15

--- a/devise-token_authenticatable.gemspec
+++ b/devise-token_authenticatable.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
 
-  spec.add_dependency "devise",                         ">= 4.0.0", "< 4.4.0"
+  spec.add_dependency "devise",                         ">= 4.0.0", "< 4.5.0"
 
   spec.add_development_dependency "rails",              "~> 4.2"
   spec.add_development_dependency "rspec-rails",        "~> 3.0"


### PR DESCRIPTION
Devise 4.4.0 ([released Dec 29](https://rubygems.org/gems/devise/versions/4.4.0)) is required on Ruby 2.5.0 due to a syntax error (https://github.com/plataformatec/devise/issues/4719).

I did the busywork to bump the devise gem requirement to allow 4.4.0. I also added Ruby 2.5.0 to the travis matrix.