### PR TITLE
update required devise version to work with ruby 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.2.5
   - 2.3.1
   - 2.4.0
+  - 2.5.0
 
 before_install:
   - gem install bundler -v 1.15

--- a/devise-token_authenticatable.gemspec
+++ b/devise-token_authenticatable.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
 
-  spec.add_dependency "devise",                         ">= 4.0.0", "< 4.4.0"
+  spec.add_dependency "devise",                         ">= 4.0.0", "< 4.5.0"
 
   spec.add_development_dependency "rails",              "~> 4.2"
   spec.add_development_dependency "rspec-rails",        "~> 3.0"


### PR DESCRIPTION
There's critical fix in devise 4.4.0 that fixes compatibility with ruby 2.5
https://github.com/plataformatec/devise/issues/4736
Please release a new version as you accept this.