### PR TITLE
Allow usage with devise 4.5

### DIFF
--- a/devise-token_authenticatable.gemspec
+++ b/devise-token_authenticatable.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
 
-  spec.add_dependency "devise",                         ">= 4.0.0", "< 4.5.0"
+  spec.add_dependency "devise",                         ">= 4.0.0", "< 4.6.0"
 
   spec.add_development_dependency "rails",              "~> 4.2"
   spec.add_development_dependency "rspec-rails",        "~> 3.0"


### PR DESCRIPTION
The test suite passes locally with devise 4.5 and it works fine in my app with devise 4.5.