### PR TITLE
Allow usage with devise 4.x

### DIFF
--- a/devise-token_authenticatable.gemspec
+++ b/devise-token_authenticatable.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
 
-  spec.add_dependency "devise",                         ">= 4.0.0", "< 4.6.0"
+  spec.add_dependency "devise",                         ">= 4.0.0", "< 5.0.0"
 
   spec.add_development_dependency "rails",              "~> 4.2"
   spec.add_development_dependency "rspec-rails",        "~> 3.0"


### PR DESCRIPTION
The test suite passes locally with devise 4.6 and it works fine in my app with devise 4.6.

This is a bit more lenient than in the past by allowing any 4.x version of devise in hopes that this gem doesn't need a version bump every time devise releases a new minor version. The commits to add support for 4.2 (56c8eea1bdc18f936ba7b40f6b2cf064193e1a03), 4.3 (7acd880161d40b422d12bcb450e3da89d9f9710d), 4.4 (6c4baaa6ae91d4287fb35bfd14a80f6613efaadf), and 4.5 (8f5fd6ae5c0a5a1da501502dd0f20142edea01f4) all required no code changes as a result of the devise upgrade.