### PR TITLE
Constrain sqlite3 gem version to match rails expected version

### DIFF
--- a/devise-token_authenticatable.gemspec
+++ b/devise-token_authenticatable.gemspec
@@ -33,7 +33,8 @@ Gem::Specification.new do |spec|
 
   # Fix database connection with sqlite3 and jruby
   if    RUBY_ENGINE == 'ruby'
-    spec.add_development_dependency "sqlite3",          "~> 1.3"
+    # Match rails's expected version constraint
+    spec.add_development_dependency "sqlite3",          "~> 1.3.6"
   elsif RUBY_ENGINE == 'jruby'
     spec.add_development_dependency "activerecord-jdbcsqlite3-adapter"
   end


### PR DESCRIPTION
sqlite3 v1.4 was released recently, but rails v4.2 expects sqlite3 ~> 1.3.6
https://github.com/rails/rails/blob/v4.2.11/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L5

The prior gemspec constraint allowed installing v1.4 for test purposes, but then the tests would fail as v1.4 didn't satisfy rails's constraint of ~> 1.3.6