### PR TITLE
Support for devise 4.6

### DIFF
--- a/devise-token_authenticatable.gemspec
+++ b/devise-token_authenticatable.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
 
-  spec.add_dependency "devise",                         ">= 4.0.0", "< 4.6.0"
+  spec.add_dependency "devise",                         ">= 4.0.0", "< 4.7.0"
 
   spec.add_development_dependency "rails",              "~> 4.2"
   spec.add_development_dependency "rspec-rails",        "~> 3.0"


### PR DESCRIPTION
Support for devise 4.6.1 which includes [security fix](https://github.com/plataformatec/devise/issues/4981) for CVE-2019-5421.

Tests pass locally.